### PR TITLE
Fix: generate unique device_id for visitors and fix player append race

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,3 +6,7 @@ Changes to be implemented in the next version
 2. When players join the lobby and are waiting for their role assignment, they can see all the other players who've joined the lobby
 3. The roles and the corresponding number on the host screen don't reset when the host resets the game. It stays persistent as long as the game room is active
 4. When the host resets the game, the players who've joined the lobby stay joined and are not kicked out. Add another "Kick all" button in the host screen to remove all the players
+
+Recent fixes
+------------
+- 2026-06-10: Fixed session/cookie collision where multiple visitors could be assigned the same `device_id` (causing duplicated players). The server now issues a secure random `device_id` for visitors without a cookie and appends new players while holding the room lock. Added `simulate_joins.py` to reproduce and verify the fix.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-This is a Online Mafia game where a moderator can host a game, have people join and then assign the roles. Each individual player can see their roles and the moderator sees them all
+Mafia Game
+
+This is an Online Mafia game where a moderator can host a game, have people join and then assign the roles. Each individual player can see their role and the moderator can see all assignments.
+
+Recent changes
+---------------
+- 2026-06-10: Fix session/cookie collision bug where multiple visitors (for example, behind the same NAT or with identical browser fingerprints) could receive the same `device_id` and be treated as the same player. The server now generates a secure random `device_id` for visitors who don't already have a cookie, and caches it per-request. The player entry append is also now performed while holding the room lock to avoid a race condition.
+
+Files added/updated for this fix
+-------------------------------
+- `mafia.py` — updated `get_device_id()` to generate secure random ids when no cookie exists and moved player append inside the lock.
+- `simulate_joins.py` — helper script to simulate multiple clients joining a room and verify unique `device_id` assignment.
+- `ChangeLog` — recorded the fix.
+
+Running locally
+---------------
+Install requirements and run the server:
+
+```bash
+pip install -r requirements.txt
+python mafia.py
+```
+
+Run the simulation (server must be running):
+
+```bash
+python simulate_joins.py
+```
+
+Notes
+-----
+- For production, set a strong `SECRET_KEY` environment variable. The `device_id` cookie is set with an expiration matching the room TTL by default.
+- If you want additional protection, consider enforcing server-side validation that the number of joined players does not exceed the total configured roles (optional enhancement).

--- a/mafia.py
+++ b/mafia.py
@@ -1,7 +1,7 @@
 
 import os
 import json
-from flask import Flask, request, jsonify, redirect, url_for, render_template, make_response, session, Response
+from flask import Flask, request, jsonify, redirect, url_for, render_template, make_response, session, Response, g
 from threading import Lock
 from flask import send_from_directory
 
@@ -65,28 +65,22 @@ def get_role_description(role_name):
 
 # Add this helper function after the imports
 def get_device_id():
-    # First try to get existing device ID from cookie (most reliable)
+    # Cache device id for the duration of this request to ensure consistency
+    if getattr(g, 'device_id', None):
+        return g.device_id
+
+    # Prefer an existing cookie if provided
     device_id = request.cookies.get('device_id')
     if device_id:
+        g.device_id = device_id
         return device_id
-    
-    # Generate deterministic device ID based on browser fingerprint (without random components)
-    ip = request.remote_addr
-    if request.headers.get('X-Forwarded-For'):
-        ip = request.headers.get('X-Forwarded-For').split(',')[0].strip()
-    
-    # Collect browser characteristics (deterministic)
-    user_agent = request.headers.get('User-Agent', '')
-    accept_language = request.headers.get('Accept-Language', '')
-    accept_encoding = request.headers.get('Accept-Encoding', '')
-    accept = request.headers.get('Accept', '')
-    
-    # Create deterministic device fingerprint (no random components)
-    import hashlib
-    device_string = f"{ip}|{user_agent}|{accept_language}|{accept_encoding}|{accept}"
-    device_id = hashlib.md5(device_string.encode()).hexdigest()[:16]
-    
-    return device_id
+
+    # No cookie -> generate a secure random device id for this visitor and cache it
+    # This avoids deterministic collisions for different users behind the same NAT/UA
+    import secrets
+    new_id = secrets.token_urlsafe(16)
+    g.device_id = new_id
+    return new_id
 
 # Helper function to ensure device cookie is always set
 def make_response_with_device_cookie(template_or_redirect, **kwargs):
@@ -363,9 +357,9 @@ def join_room(room_name):
             return redirect(url_for('join_page', room_name=room_name, error='Name already taken'))
 
         # Add new player with device ID (only if device hasn't joined before)
-    room['players'].append({'name': name, 'device_id': player_ip})
-    # Pre-assign a chat color for this player to avoid flash on first message
-    _assign_chat_color_for_player(room, name)
+        room['players'].append({'name': name, 'device_id': player_ip})
+        # Pre-assign a chat color for this player to avoid flash on first message
+        _assign_chat_color_for_player(room, name)
 
     resp = make_response_with_device_cookie('thanks.html', name=name, room_name=room_name, player_ip=player_ip)
     resp.set_cookie('player_name', name, max_age=COOKIE_TTL)      # Changed from ROOM_TTL

--- a/simulate_joins.py
+++ b/simulate_joins.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+import time, sys
+
+# ensure requests is installed
+try:
+    import requests
+except Exception:
+    import subprocess, sys
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'requests'])
+    import requests
+
+BASE = 'http://127.0.0.1:5051'
+
+def wait_for_server(timeout=10.0):
+    import time
+    for _ in range(int(timeout * 5)):
+        try:
+            r = requests.get(BASE + '/healthz', timeout=1)
+            if r.status_code == 200:
+                return True
+        except Exception:
+            pass
+        time.sleep(0.2)
+    return False
+
+if not wait_for_server(10):
+    print('Server not reachable, exiting', file=sys.stderr)
+    sys.exit(2)
+
+ROOM = 'testroom_sim_' + str(int(time.time()))
+HOST_PW = 'hp'
+
+hs = requests.Session()
+print('Creating room', ROOM)
+resp = hs.post(BASE + '/create_room', data={'room_name': ROOM, 'host_password': HOST_PW}, allow_redirects=True, timeout=5)
+print('create_room status', resp.status_code)
+host_token = hs.cookies.get('host_token')
+print('host_token cookie present:', bool(host_token))
+if not host_token:
+    print('No host token; abort', file=sys.stderr)
+    sys.exit(3)
+
+# Add a single role with count=2 (total roles < expected number of clients)
+resp = hs.post(f'{BASE}/api/rooms/{ROOM}/roles', data={'role_name': 'Villager', 'role_count': '2', 'role_faction': ''}, timeout=5)
+print('/roles add', resp.status_code, resp.text)
+
+NUM_CLIENTS = 4
+clients = []
+names = []
+for i in range(NUM_CLIENTS):
+    s = requests.Session()
+    name = f'Player{i+1}'
+    r = s.get(f'{BASE}/room/{ROOM}', timeout=5)
+    print(f'Client {name} GET /room status', r.status_code)
+    r2 = s.post(f'{BASE}/room/{ROOM}/join', data={'name': name, 'password': ''}, allow_redirects=True, timeout=5)
+    print(f'Client {name} POST /join status', r2.status_code)
+    clients.append(s)
+    names.append(name)
+    time.sleep(0.05)
+
+# Query debug info
+dbg = hs.get(f'{BASE}/api/rooms/{ROOM}/debug', timeout=5)
+print('DEBUG status', dbg.status_code)
+try:
+    js = dbg.json()
+except Exception as e:
+    print('Failed to parse debug json', dbg.text, file=sys.stderr)
+    sys.exit(4)
+
+print('Players in room:', len(js.get('players', [])))
+for p in js.get('players', []):
+    print(' -', p.get('name'), p.get('device_id'))
+
+device_ids = [p.get('device_id') for p in js.get('players', [])]
+unique = set(device_ids)
+print('Unique device_ids:', len(unique), 'Expected:', NUM_CLIENTS)
+for idx, s in enumerate(clients):
+    print('Client', names[idx], 'cookies device_id=', s.cookies.get('device_id'), 'player_name=', s.cookies.get('player_name'))
+
+if len(unique) == NUM_CLIENTS:
+    print('PASS: all device_ids unique')
+    sys.exit(0)
+else:
+    print('FAIL: duplicate device_ids found', file=sys.stderr)
+    sys.exit(5)


### PR DESCRIPTION
This PR fixes a bug where multiple visitors (for example behind the same NAT or with identical browser fingerprints) could receive the same `device_id` and be treated as the same player. Changes:

- Generate a secure random `device_id` for visitors who don't already have a cookie (cached per-request).
- Move the `room['players'].append(...)` and chat color assignment inside the room lock to avoid races.
- Add `simulate_joins.py` to reproduce and verify uniqueness of `device_id` across multiple simulated clients.
- Update `README.md` and `ChangeLog` to document the change and testing steps.

I ran the included simulation locally against the running server and confirmed each simulated client received a distinct `device_id` cookie.
